### PR TITLE
[feature] paramdict type 지정할 수 있도록 변경

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -282,7 +282,7 @@ def test_debug(args, targets, samples, B=0, h=224, w=224):
             x = int( t[j][0] * w )
             y = int( t[j][1] * h )
             cv2.line(img, (x, y), (x, y), color[i], 5)
-    # plt.imshow(img)
+    # plt.imsave('test.png', img)
     plt.imshow(img)
 
     # samples, targets, meta_info = prefetcher.next()


### PR DESCRIPTION
```
python -m torch.distributed.launch --nproc_per_node=4 main.py \
--modelname dino \
--output_dir weights/DINO/new_dino/2_ARCTIC-155-143-DINO-4s-r50-onecyclelr \
--coco_path .. \
--dataset_file arctic \
--resume weights/DINO/new_dino/1_ARCTIC-143-95-DINO-4s-r50-onecyclelr/143.pth \
--method arctic_lstm \
--start_epoch 144 \
--epochs 500 \
--batch_size 2 \
--val_batch_size 2 \
--window_size 24 \
--split_window \
--full_validation \
-c config/DINO/DINO_4scale.py \
--options dn_scalar=100 embed_init_tgt=TRUE \
dn_label_coef=1.0 dn_bbox_coef=1.0 use_ema=False \
dn_box_noise_scale=1.0 lr=1e-7 param_dict_type=ddetr_in_mmdet \
--onecyclelr \
--not_use_optim_ckpt \
--not_use_lr_scheduler_ckpt \
--use_augm \
--wandb
```

```
python -m torch.distributed.launch --nproc_per_node=4 main.py \
--modelname dino \
--output_dir weights/DINO/new_dino/2_ARCTIC-155-143-DINO-4s-r50-onecyclelr \
--coco_path .. \
--dataset_file arctic \
--resume weights/DINO/new_dino/2_ARCTIC-155-143-DINO-4s-r50-onecyclelr/145.pth \
--method arctic_lstm \
--start_epoch 146 \
--epochs 158 \
--batch_size 2 \
--val_batch_size 2 \
--window_size 24 \
--split_window \
--full_validation \
-c config/DINO/DINO_4scale.py \
--options dn_scalar=100 embed_init_tgt=TRUE \
dn_label_coef=1.0 dn_bbox_coef=1.0 use_ema=False \
dn_box_noise_scale=1.0 lr=1e-4 param_dict_type=ddetr_in_mmdet \
--not_use_lr_scheduler_ckpt \
--use_augm \
--wandb

```